### PR TITLE
g:mingdb_gdbinit_path to override .gdbinit path

### DIFF
--- a/autoload/minimal_gdb.vim
+++ b/autoload/minimal_gdb.vim
@@ -15,12 +15,18 @@ function! s:EnsurePythonInitialization()
         exe 'python3 sys.path.insert(0, "' . s:script_folder_path . '/../python")'
         py3 import mingdb
         py3 mingdb.InitCacheFlag()
+        if exists("g:mingdb_gdbinit_path")
+            py3 mingdb.GDB_INIT_PATH = vim.eval('expand(g:mingdb_gdbinit_path)')
+        endif
     else
         py import sys
         py import vim
         exe 'python sys.path.insert(0, "' . s:script_folder_path . '/../python")'
         py import mingdb
         py mingdb.InitCacheFlag()
+        if exists("g:mingdb_gdbinit_path")
+            py mingdb.GDB_INIT_PATH = vim.eval('expand(g:mingdb_gdbinit_path)')
+        endif
     endif
     "if pyeval('mingdb.DatabaseIsEmpty()')
     "    let s:debug_session_is_active_cache_flag = 0


### PR DESCRIPTION
Allows user to set g:mingdb_gdbinit_path in .vimrc to override ~/.gdbinit path for users who have more complex .gdbinit setups.