### PR TITLE
List all breakpoints in the quickfix window

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The script will configure everything when you set a first breakpoint.
 ## COMMANDS:
 ### In vim:
 * `MinGDBToggleBP` or `<leader>b` - toggles a breakpoint.
-* `MinGDBDeleteAll` - delete all breakpoints
+* `MinGDBDeleteAll` - delete all breakpoints.
+* `MinGDBListAll` - list all breakpoints in the quickfix window.
 * `MinGDBRefreshFile` - refresh breakpoints positions in a vim file. Use this in case something went wrong.
 
 ### In gdb:

--- a/autoload/minimal_gdb.vim
+++ b/autoload/minimal_gdb.vim
@@ -62,6 +62,15 @@ function minimal_gdb#delete_all()
     redraw!
 endfunction
 
+function minimal_gdb#list_all()
+    call s:EnsurePythonInitialization()
+    if has("python3")
+        py3 mingdb.ListAllBreakpoints()
+    else
+        py mingdb.ListAllBreakpoints()
+    endif
+endfunction
+
 function minimal_gdb#show_breakpoints()
     if (!s:debug_session_is_active_cache_flag)
         return

--- a/plugin/minimal_gdb.vim
+++ b/plugin/minimal_gdb.vim
@@ -11,6 +11,7 @@ com! MinGDBToggleBP cal minimal_gdb#toggle()
 com! MinGDBDeleteAll cal minimal_gdb#delete_all()
 com! MinGDBShowBreakpoints cal minimal_gdb#show_breakpoints()
 com! MinGDBRefreshFile MinGDBShowBreakpoints
+com! MinGDBListAll cal minimal_gdb#list_all()
 
 nnoremap <Leader>b :MinGDBToggleBP<CR>
 autocmd BufRead * cal MinGDBCheckFileType()

--- a/pythonx/mingdb.py
+++ b/pythonx/mingdb.py
@@ -100,6 +100,25 @@ def ReadBreakpoints():
     return result
 
 
+def ListAllBreakpoints():
+    result = ReadBreakpoints()
+    import tempfile
+    f = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    filename = f.name
+    for bp in result:
+        lineNumber = RestoreLineNumber(bp)
+        f.write(bp.File)
+        f.write(':')
+        f.write(str(lineNumber))
+        f.write(': ')
+        f.write(bp.Line)
+        f.write('\n')
+    f.close()
+
+    ExecuteVimCommand("cg {}".format(filename))
+    ExecuteVimCommand('copen')
+
+
 def GetMaxId(breakpoints):
     if not len(breakpoints):
         return BREAKPOINT_START_ID


### PR DESCRIPTION
Hello,

I wanted to make a similar plugin then I found yours which is exactly what I had in mind.
Good job!

Here is a feature that list all the breakpoints in the quickfix window. This is useful to cycle and jump to the different breakpoints.

At thi moment it lists all the breakpoints so it might be interesting to consider a local .gdbinit file per project. What do you think?

Tell me if you want me to change anything in this PR.


